### PR TITLE
Remove keys on timeout and lint cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 2.1.0
+
+This is sort of a bugfix, sort of a new feature. But basically now the "bound" keys get reset after 500ms of not having keydown events.
+This should alleviate times where the "bound" keys get out of whack.
+
+# 2.0.0 and prior
+See github tagged releases

--- a/dist/shortcut.js
+++ b/dist/shortcut.js
@@ -180,7 +180,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	}
 
-	;
 	module.exports = exports["default"];
 
 /***/ },
@@ -506,7 +505,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	    e.returnValue = false; // IE prevent Default
 	    return false; // Safari Prevent Default
-	  };
+	  }
 
 	  this.bindsTo(_preventDefault);
 
@@ -546,7 +545,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      e.stopPropagation();
 	    }
 	    return false; // Safari Prevent Default
-	  };
+	  }
 
 	  this.bindsTo(_stopPropagation);
 
@@ -722,7 +721,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	    return this;
 	  }
 
-	  var keys = this.keys.split(' ');
 	  var event = new KeyboardEvent('keydown', {});
 
 	  (0, _EventBinding.callShortcutFunctions)(this.keys, this.domNode, event);
@@ -774,6 +772,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var _Shortcut2 = _interopRequireDefault(_Shortcut);
 
 	var downKeys = [];
+	var clearDownKeysTimeout = undefined;
 
 	/*
 	 * When a key is pressed, we add it to the internal array, and check if we have any matches to fire functions
@@ -784,6 +783,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 
 	  downKeys.push((0, _EvaluateKey2['default'])(e));
+
+	  clearTimeout(clearDownKeysTimeout);
+	  clearDownKeysTimeout = setTimeout(function clearKeys() {
+	    downKeys = [];
+	  }, 500);
 
 	  var downKeyString = downKeys.join(' ');
 	  var domNode = e.target;
@@ -832,7 +836,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var shortcutFns = shortcutInstance.functions();
 	  var allowPropagationToBody = true;
 
-	  e.stopPropagation = function () {
+	  e.stopPropagation = function propagationStopper() {
 	    allowPropagationToBody = false;
 	  };
 
@@ -899,20 +903,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	function evaluateKey(e) {
 	  var OS_MAP = _defineProperty({}, osModKeyName(), 'mod');
 
-	  // grap character for special cases
+	  // grab character for special cases
 	  var character = specialCases(e.keyCode);
 
 	  if (OS_MAP[character]) {
-	    // grap character for special cases
+	    // grab character for special cases
 	    character = OS_MAP[character];
-	  }
-
-	  /*
-	   * if the character doesnt match a special case
-	   * we just can trust the charCode lookup method
-	   */
-	  if (!character) {
-	    character = String.fromCharCode(e.keyCode || e.charCode).toLowerCase();
 	  }
 
 	  return character;
@@ -965,6 +961,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	      break;
 	    case 13:
 	      character = 'rtn';
+	      break;
+	    default:
+	      /*
+	       * if the character doesnt match a special case
+	       * we just can trust the charCode lookup method
+	       */
+	      character = String.fromCharCode(e.keyCode || e.charCode).toLowerCase();
 	      break;
 	  }
 

--- a/dist/shortcut.js
+++ b/dist/shortcut.js
@@ -303,8 +303,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	  if (_Mappings2['default'][shortcutStr] === undefined) {
 	    _Mappings2['default'][shortcutStr] = {};
 	  }
+
 	  if (_Mappings2['default'][shortcutStr][domNode] === undefined) {
-	    _Mappings2['default'][shortcutStr][domNode] = [];
+	    _Mappings2['default'][shortcutStr][domNode] = { keyDown: [], keyUp: [] };
 	  }
 
 	  // decides if the shortcut is paused
@@ -312,13 +313,14 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	  // Chaining methods
 	  return {
-	    bindsTo: _BindsTo2['default'],
+	    bindsTo: _BindsTo2['default'].bind(null, 'keyUp'),
 	    domNode: domNode,
 	    functions: function functions() {
 	      return _Mappings2['default'][shortcutStr][domNode];
 	    },
 	    isPaused: isPaused,
 	    keys: shortcutStr,
+	    onKeyDown: _BindsTo2['default'].bind(null, 'keyDown'),
 	    pause: _Pause2['default'],
 	    preventDefault: _PreventDefault2['default'],
 	    stopPropagation: _StopPropagation2['default'],
@@ -428,13 +430,13 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	var _Error2 = _interopRequireDefault(_Error);
 
-	function bindsTo(fn) {
+	function bindsTo(location, fn) {
 	  // Stop if not a function
 	  if (typeof fn !== 'function') {
 	    return (0, _Error2['default'])('You must pass a function to the bindsTo method, check the call for the shortcut(\'' + this.keys + '\', \'' + this.domNode.name + '\') method');
 	  }
 
-	  _Mappings2['default'][this.keys][this.domNode].push(fn);
+	  _Mappings2['default'][this.keys][this.domNode][location].push(fn);
 
 	  // Return this for chaning
 	  return this;

--- a/example.html
+++ b/example.html
@@ -39,5 +39,8 @@
   shortcut('up', document.getElementById('phone')).stopPropagation().bindsTo(log);
   shortcut('up', document.body).bindsTo(windowfn);
 
+  shortcut('tab', document.body).preventDefault().bindsTo(function(){ console.log('tab')});
+  shortcut('shift tab', document.body).preventDefault().bindsTo(function(){ console.log('shift tab')});
+
   shortcut('up', document.getElementById('phone')).trigger();
 </script>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "karma-safari-launcher": "~0.1.1"
   },
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js test"
+    "test": "./node_modules/gulp/bin/gulp.js test",
+    "build": "webpack",
+    "watch": "webpack --watch"
   },
   "dependencies": {
     "babel-eslint": "^3.1.30",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut.js",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "./dist/shortcut.js",
   "author": "Blaine Kasten <blainekasten@gmail.com>",
   "keywords": [

--- a/src/BindsTo.js
+++ b/src/BindsTo.js
@@ -15,13 +15,13 @@
 import mappings from './Mappings';
 import error from './Error';
 
-export default function bindsTo(fn: Function) : Object {
+export default function bindsTo(location: string, fn: Function) : Object {
   // Stop if not a function
   if (typeof fn !== 'function'){
     return error(`You must pass a function to the bindsTo method, check the call for the shortcut('${this.keys}', '${this.domNode.name}') method`);
   }
 
-  mappings[this.keys][this.domNode].push(fn);
+  mappings[this.keys][this.domNode][location].push(fn);
 
   // Return this for chaning
   return this;

--- a/src/EvaluateKey.js
+++ b/src/EvaluateKey.js
@@ -16,21 +16,12 @@ export default function evaluateKey(e: Event) : string {
     [osModKeyName()]: 'mod',
   };
 
-  // grap character for special cases
-  let character: string = specialCases(e.keyCode);
+  // grab character for special cases
+  let character:string = specialCases(e.keyCode);
 
   if (OS_MAP[character]) {
-    // grap character for special cases
+    // grab character for special cases
     character = OS_MAP[character];
-  }
-
-
-  /*
-   * if the character doesnt match a special case
-   * we just can trust the charCode lookup method
-   */
-  if (!character) {
-    character = String.fromCharCode(e.keyCode || e.charCode).toLowerCase();
   }
 
   return character;
@@ -41,49 +32,56 @@ export default function evaluateKey(e: Event) : string {
  * this maps to readable words that can be used for the shortcut
  * library
  */
-function specialCases(keyCode: string) : string {
-  let character: string;
+function specialCases(keyCode:string) : string {
+  let character:string;
 
-  switch(keyCode){
-    case 190:
-      character = '.';
-      break;
-    case 224: //firefox meta
-      character = 'meta';
-      break;
-    case 91:
-      character = 'meta';
-      break;
-    case 16:
-      character = 'shift';
-      break;
-    case 18:
-      character = 'optn';
-      break;
-    case 17:
-      character = 'ctrl';
-      break;
-    case 32:
-      character = 'space';
-      break;
-    case 40:
-      character = 'down';
-      break;
-    case 39:
-      character = 'right';
-      break;
-    case 38:
-      character = 'up';
-      break;
-    case 37:
-      character = 'left';
-      break;
-    case 9:
-      character = 'tab';
-      break;
-    case 13:
-      character = 'rtn';
-      break;
+  switch(keyCode) {
+  case 190:
+    character = '.';
+    break;
+  case 224: //firefox meta
+    character = 'meta';
+    break;
+  case 91:
+    character = 'meta';
+    break;
+  case 16:
+    character = 'shift';
+    break;
+  case 18:
+    character = 'optn';
+    break;
+  case 17:
+    character = 'ctrl';
+    break;
+  case 32:
+    character = 'space';
+    break;
+  case 40:
+    character = 'down';
+    break;
+  case 39:
+    character = 'right';
+    break;
+  case 38:
+    character = 'up';
+    break;
+  case 37:
+    character = 'left';
+    break;
+  case 9:
+    character = 'tab';
+    break;
+  case 13:
+    character = 'rtn';
+    break;
+  default:
+    /*
+     * if the character doesnt match a special case
+     * we just can trust the charCode lookup method
+     */
+    character = String.fromCharCode(e.keyCode || e.charCode).toLowerCase();
+    break;
   }
 
   return character;

--- a/src/EventBinding.js
+++ b/src/EventBinding.js
@@ -14,7 +14,8 @@ import globalPause from './GlobalPause';
 import mappings from './Mappings';
 import shortcut from './Shortcut';
 
-const downKeys: Array<string> = [];
+let downKeys: Array<string> = [];
+let clearDownKeysTimeout;
 
 /*
  * When a key is pressed, we add it to the internal array, and check if we have any matches to fire functions
@@ -26,12 +27,17 @@ function onKeyDown(e: KeyboardEvent) : void {
 
   downKeys.push(evaluateKey(e));
 
+  clearTimeout(clearDownKeysTimeout);
+  clearDownKeysTimeout = setTimeout(function clearKeys() {
+    downKeys = [];
+  }, 500);
+
   const downKeyString: string = downKeys.join(' ');
   const domNode: HTMLElement = e.target;
 
   // there is no shortcut bound for this set of
   // keys pressed, so stop
-  if (mappings[downKeyString] === undefined){
+  if (mappings[downKeyString] === undefined) {
     return;
   }
 
@@ -74,14 +80,14 @@ export function callShortcutFunctions(downKeyString: string, domNode: HTMLElemen
   const shortcutFns: Array<Function> = shortcutInstance.functions();
   let allowPropagationToBody: boolean = true;
 
-  e.stopPropagation = function() {
+  e.stopPropagation = function propagationStopper() {
     allowPropagationToBody = false;
-  }
+  };
 
   // Call functions
-  for (const i in shortcutFns){
+  for (const i in shortcutFns) {
     if (shortcutFns.hasOwnProperty(i)) {
-      shortcutFns[i](e)
+      shortcutFns[i](e);
     }
   }
 
@@ -90,8 +96,6 @@ export function callShortcutFunctions(downKeyString: string, domNode: HTMLElemen
     callShortcutFunctions(downKeyString, document.body, e);
   }
 }
-
-
 
 
 /*
@@ -105,7 +109,7 @@ export default function eventBinding() : void {
   }
 
   if ( !/Mobi/.test(navigator.userAgent)) {
-    if (window.addEventListener){
+    if (window.addEventListener) {
       window.addEventListener('keydown', onKeyDown);
       window.addEventListener('keyup', onKeyUp);
     } else {
@@ -113,5 +117,4 @@ export default function eventBinding() : void {
       document.attachEvent('onkeyup', onKeyUp);
     }
   }
-
 }

--- a/src/GlobalPause.js
+++ b/src/GlobalPause.js
@@ -12,9 +12,9 @@
  * @providesModule Error
  */
 
-let globalPause: boolean = false;
+let globalPause:boolean = false;
 
-export default function globalPause(setter: boolean) : boolean {
+export default function globalPause(setter:boolean) : boolean {
   if (typeof setter === 'boolean') {
     globalPause = setter;
   }

--- a/src/IndexOfPolyfill.js
+++ b/src/IndexOfPolyfill.js
@@ -10,7 +10,7 @@
  */
 
 export default function indexOfPolyfill() : void {
-  if (!Array.prototype.indexOf){
+  if (!Array.prototype.indexOf) {
     Array.prototype.indexOf = function indexOf(element) {
       const length = this.length >>> 0;
 
@@ -31,4 +31,4 @@ export default function indexOfPolyfill() : void {
       return -1;
     };
   }
-};
+}

--- a/src/PreventDefault.js
+++ b/src/PreventDefault.js
@@ -13,14 +13,14 @@
  */
 
 export default function preventDefault() : object {
-  function _preventDefault(e){
-    if (e.preventDefault){
+  function _preventDefault(e) {
+    if (e.preventDefault) {
       e.preventDefault();
     }
 
     e.returnValue = false; // IE prevent Default
     return false; // Safari Prevent Default
-  };
+  }
 
   this.bindsTo(_preventDefault);
 

--- a/src/StopPropagation.js
+++ b/src/StopPropagation.js
@@ -13,12 +13,12 @@
  */
 
 export default function stopPropagation() : object {
-  function _stopPropagation(e){
-    if (e.stopPropagation){
+  function _stopPropagation(e) {
+    if (e.stopPropagation) {
       e.stopPropagation();
     }
     return false; // Safari Prevent Default
-  };
+  }
 
   this.bindsTo(_stopPropagation);
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@
  * @providesModule shortcut
  */
 
-import indexofPolyfill from './IndexOfPolyfill';
+import indexOfPolyfill from './IndexOfPolyfill';
 import globalPause from './GlobalPause';
 import shortcut from './Shortcut';
 import eventBinding from './EventBinding';
 
-indexofPolyfill();
+indexOfPolyfill();
 eventBinding();
 
 /*
@@ -24,7 +24,7 @@ eventBinding();
  * @chainable
  */
 
-shortcut.pause = function pause() : object {
+shortcut.pause = function pause() : Object {
   globalPause(true);
 
   return shortcut;
@@ -37,7 +37,7 @@ shortcut.pause = function pause() : object {
  * @chainable
  */
 
-shortcut.resume = function resume() : object {
+shortcut.resume = function resume() : Object {
   globalPause(false);
 
   return shortcut;

--- a/src/pause.js
+++ b/src/pause.js
@@ -15,7 +15,7 @@ import pausedMappings from './PausedMappings';
 
 export default function pause() : Object {
   // check if element and keys exists in mappings
-  if (pausedMappings[this.keys] === undefined){
+  if (pausedMappings[this.keys] === undefined) {
     pausedMappings[this.keys] = this.domNode;
   }
 

--- a/src/resume.js
+++ b/src/resume.js
@@ -17,7 +17,7 @@ import pausedMappings from './PausedMappings';
 export default function resume() : object {
 
   // destroy key/value of this.keys
-  if (pausedMappings[this.keys]){
+  if (pausedMappings[this.keys]) {
     delete pausedMappings[this.keys];
   }
 

--- a/src/shortcut.js
+++ b/src/shortcut.js
@@ -41,19 +41,25 @@ export default function shortcut(shortcutStr: string, domNode: HTMLElement) : ob
   }
 
   // check if element and keys exists in mappings
-  if (mappings[shortcutStr] === undefined){ mappings[shortcutStr] = {}; }
-  if (mappings[shortcutStr][domNode] === undefined){ mappings[shortcutStr][domNode] = []; }
+  if (mappings[shortcutStr] === undefined){
+    mappings[shortcutStr] = {};
+  }
+
+  if (mappings[shortcutStr][domNode] === undefined) {
+    mappings[shortcutStr][domNode] = { keyDown: [], keyUp: [] };
+  }
 
   // decides if the shortcut is paused
   const isPaused: boolean = pausedMappings[shortcutStr] === domNode ? true : false;
 
   // Chaining methods
   return {
-    bindsTo,
+    bindsTo: bindsTo.bind(null, 'keyUp'),
     domNode,
     functions: () => mappings[shortcutStr][domNode],
     isPaused,
     keys: shortcutStr,
+    onKeyDown: bindsTo.bind(null, 'keyDown'),
     pause,
     preventDefault,
     stopPropagation,

--- a/src/trigger.js
+++ b/src/trigger.js
@@ -17,12 +17,11 @@ import globalPause from './GlobalPause';
 import { callShortcutFunctions } from './EventBinding';
 
 export default function trigger() : object {
-  if (globalPause() || this.isPaused){
+  if (globalPause() || this.isPaused) {
     return this;
   }
 
-  const keys: Array<string> = this.keys.split(' ');
-  const event: KeyboardEvent = new KeyboardEvent('keydown', {});
+  const event:KeyboardEvent = new KeyboardEvent('keydown', {});
 
   callShortcutFunctions(this.keys, this.domNode, event);
 


### PR DESCRIPTION
Sometimes keys get in goofy states. This at least removes the bound keys after a 500ms timeout.
