### PR TITLE
Remove `engine` entry in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shortcut.js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "./dist/shortcut.js",
   "author": "Blaine Kasten <blainekasten@gmail.com>",
   "keywords": [
@@ -11,9 +11,6 @@
   ],
   "licenses": {
     "type": "MIT"
-  },
-  "engines": {
-    "iojs": "1.6.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This engine entry was very old, stating dependency on `iojs`. This was making it non-installable with yarn.
